### PR TITLE
Update supported Ubuntu versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,12 +75,16 @@ chmod +x deploy.sh
 
 ## UbuntuのバージョンとCodeNameの指定対応
 
-| Ubuntu Version | CodeName |
-|:--------------:|:--------:|
-| 24.04.1 LTS | noble |
-| 22.04.5 LTS | jammy |
-| 20.04.6 LTS | focal |
-| 18.04.6 LTS | bionic |
+| Ubuntu Version | CodeName | 備考 |
+|:--------------:|:--------:|:----:|
+| 25.10 | questing | 最新 |
+| 25.04 | plucky | |
+| 24.04 LTS | noble | 推奨（長期サポート） |
+| 22.04 LTS | jammy | 長期サポート |
+| 20.04 LTS | focal | 標準サポート終了 |
+| 18.04 LTS | bionic | EOL（非推奨） |
+
+> **注意**: 上記以外のコードネームでも、[cloud-images.ubuntu.com](https://cloud-images.ubuntu.com/) にイメージが存在すれば利用可能です。
 
 ## 参考
 - https://pve.proxmox.com/wiki/Cloud-Init_Support

--- a/README.md
+++ b/README.md
@@ -77,8 +77,7 @@ chmod +x deploy.sh
 
 | Ubuntu Version | CodeName | 備考 |
 |:--------------:|:--------:|:----:|
-| 25.10 | questing | 最新 |
-| 25.04 | plucky | |
+| 26.04 LTS | resolute | 最新（長期サポート） |
 | 24.04 LTS | noble | 推奨（長期サポート） |
 | 22.04 LTS | jammy | 長期サポート |
 | 20.04 LTS | focal | 標準サポート終了 |


### PR DESCRIPTION
## Summary
- Ubuntu 25.10 (questing) と 25.04 (plucky) を対応バージョン一覧に追加
- 各バージョンのLTS/EOL状態が分かるよう「備考」列を追加
- cloud-images.ubuntu.com にイメージがあれば表に載っていないコードネームでも利用可能な旨を注記

## Test plan
- [ ] `./setup.sh 9000 questing 4096` で Ubuntu 25.10 のテンプレートが作成できること
- [ ] `./setup.sh 9000 plucky 4096` で Ubuntu 25.04 のテンプレートが作成できること
- [ ] 既存のコードネーム (noble, jammy等) が引き続き動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)